### PR TITLE
빈 목록에 대해서 공통적으로 사용할 수 있는 공통 컴포넌트 추가

### DIFF
--- a/src/components/Shared/EmptyListPlaceholder.js
+++ b/src/components/Shared/EmptyListPlaceholder.js
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const PlaceHolder = styled.div`
+  text-align: center;
+  padding: ${(props) => props.padding || '3rem'};
+  margin: ${(props) => props.margin || '1rem 1rem'};
+  border-radius: ${(props) => props.borderRadius || '0.5rem'};
+  font-size: ${(props) => props.fontSize || '1.1rem;'};
+  background-color: ${(props) => props.backgroundColor || props.theme.color_background__secondary};
+`;
+
+const EmptyListPlaceHolder = ({
+  message,
+  backgroundColor,
+  padding,
+  margin,
+  borderRadius,
+  fontSize,
+}) => {
+  return (
+    <PlaceHolder
+      backgroundColor={backgroundColor}
+      padding={padding}
+      margin={margin}
+      borderRadius={borderRadius}
+      fontSize={fontSize}
+    >
+      {message}
+    </PlaceHolder>
+  )
+};
+
+export default EmptyListPlaceHolder;

--- a/src/pages/AuctionAuctioneer/Auctioneer.js
+++ b/src/pages/AuctionAuctioneer/Auctioneer.js
@@ -14,6 +14,7 @@ import { useProductGroupsQuery, useSingleAuctionQuery } from 'queries/auction';
 import useInput from 'hooks/useInput';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
+import EmptyListPlaceHolder from 'components/Shared/EmptyListPlaceholder';
 
 const Container = styled.div`
   height: 100%;
@@ -177,21 +178,25 @@ const Auctioneer = () => {
             <SelectBtn onClick={SelecthandleModal}>선택</SelectBtn>
             <DiscardBtn onClick={DiscardhandleModal}>폐기</DiscardBtn>
             <BuyerList>
-              <MyRadioGroup name="buyer-radio-group">
-                {productGroups?.results.map((singleGroup) => {
-                  return (
-                    <BuyerContainer>
-                      <FormControlLabel
-                        control={<StyledRadio />}
-                        {...selectedProductGroupControlProps(
-                          `${singleGroup?.id}`
-                        )}
-                      />
-                      <BuyerSingleBox singleGroup={singleGroup} />
-                    </BuyerContainer>
-                  );
-                })}
-              </MyRadioGroup>
+              {
+                productGroups?.total_count > 0 ? (
+                  <MyRadioGroup name="buyer-radio-group">
+                    {productGroups?.results.map((singleGroup) => {
+                      return (
+                        <BuyerContainer>
+                          <FormControlLabel
+                            control={<StyledRadio />}
+                            {...selectedProductGroupControlProps(
+                              `${singleGroup?.id}`
+                            )}
+                          />
+                          <BuyerSingleBox singleGroup={singleGroup} />
+                        </BuyerContainer>
+                      );
+                    })}
+                  </MyRadioGroup>
+                ) : <EmptyListPlaceHolder message="아직 경매 참여자가 없습니다 🥺" />
+              }
             </BuyerList>
             <PaginationContainer>
               <StyledPagination


### PR DESCRIPTION
## 작업 내용
- 빈 목록에 대해서 공통적으로 사용할 수 있는 공통 컴포넌트 추가
  - 최대한 커스텀할 수 있게 props로 다 열어두었습니다. 그렇기 때문에 사용처에서 추가적으로 크기를 조절할 수 있습니다.
  - 아래와 같이 사용 가능합니다.
  ```jsx
    <EmptyListPlaceHolder message="test" margin="1rem 1rem" padding="1rem 0rem 1rem 0rem" backgroundColor="#ff0000"/>
  ```
![image](https://user-images.githubusercontent.com/47373998/184626692-dc7d70e7-cd37-4828-a3ad-52973cc6ee85.png)

## 희망 완료일
- ASAP
