### PR TITLE
style: 마이페이지-히스토리 Right Container UI 스타일  수정

### DIFF
--- a/src/components/MyPage/TransactionHistory.js
+++ b/src/components/MyPage/TransactionHistory.js
@@ -204,6 +204,7 @@ const RightContainer = styled.div`
 const RightSmallContainer = styled.div`
   position: relative;
   flex: 1;
+  height: 6rem;
   margin-bottom: 1rem;
   padding: 1rem 1.5rem;
   border-radius: 0.5rem;
@@ -214,10 +215,10 @@ const RankInfo = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  height: 2.5rem;
+  padding-bottom: 1rem;
   font-size: 2.5rem;
   font-weight: 600;
-  height: 2.5rem;
-
   @media screen and (max-width: 1000px) {
     font-size: 2rem;
   }
@@ -225,11 +226,10 @@ const RankInfo = styled.div`
 
 const MyScopeInfoContainer = styled.div`
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   width: 100%;
   height: 50%;
-  padding-right: 5%;
 `;
 
 const MyScopeInfo = styled(StarIcon)`
@@ -260,18 +260,19 @@ const MyScopeInfo = styled(StarIcon)`
 
 const DealCountInfoContainer = styled.div`
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   width: 100%;
-  height: 70%;
-  padding-right: 5%;
+  height: 2rem;
+  margin-bottom: 1rem;
 `;
 
 const DealCountInfo = styled.div`
-  display: flex;
+  display: inline-flex;
+  flex-direction: flex-start;
   justify-content: center;
   align-items: center;
-  padding-right: 5%;
+  height: 2rem;
   font-size: 1rem;
   font-weight: bold;
   span {


### PR DESCRIPTION
## 작업 내용
- 마이페이지 히스토리 Right Container UI 수정
  - '랭크'란의 'S' 부분 padding-bottom: 1rem
  - 내 평점 별 사이 간격 넓히기 / 컨테이너 height 조금 높이기
  - 거래 횟수의 '총 n회' 가운데 정렬

## 참고 자료
- <img width="178" alt="image" src="https://user-images.githubusercontent.com/102042966/185240854-23823b44-7ca8-4390-83bc-176953b94057.png">

## 기타 사항
- 노션의 "emptylistplaceholder 문구 중간에 한번 줄바꿈 / ‘한번 경매장에 참여해볼까요?’ hover하면 밑줄 생기고 경매장으로 바로 이동이 가능하게끔‘" 는 채원이가 이어서 해 줄 예정

## 희망 완료일
- 
