### PR TITLE
style: 마이페이지 히스토리 placeholder 배경&거래횟수 숫자 배열 수정

### DIFF
--- a/src/components/MyPage/InterestedAuctionList.js
+++ b/src/components/MyPage/InterestedAuctionList.js
@@ -56,7 +56,6 @@ const InterestedAuctionList = () => {
     <ItemListContainer>
       {interestedAuctionListsFetched && (
         <>
-          {/*<p>총 {interestedAuctionLists?.total_count}개</p>*/}
           <CountText>총 {interestedAuctionLists?.total_count}개</CountText>
           {
             interestedAuctionLists?.total_count > 0 ? (

--- a/src/components/MyPage/TransactionHistory.js
+++ b/src/components/MyPage/TransactionHistory.js
@@ -268,7 +268,7 @@ const MyScopeInfo = styled(StarIcon)`
 
 const DealCountInfoContainer = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   width: 100%;
   height: 2rem;
@@ -289,7 +289,7 @@ const DealCountInfo = styled.div`
 `;
 
 const DealCount = styled.p`
-  padding: 0 0.5rem 0 1rem;
+  padding: 0 1rem 0 1rem;
   font-size: 2rem;
 `;
 
@@ -475,7 +475,6 @@ const TransactionHistory = () => {
                 <EmptyListPlaceHolder
                   message="아직 경매장에서 거래한 물건이 없습니다.🥺 한 번 경매장에 참여해볼까요?"
                   margin="0"
-                  backgroundColor="#252040"
                 />
               </StyledLink>
             )}

--- a/src/components/Shared/EmptyListPlaceholder.js
+++ b/src/components/Shared/EmptyListPlaceholder.js
@@ -1,15 +1,5 @@
 import styled from 'styled-components';
-/*
-const PlaceHolder = styled.div`
-  text-align: center;
-  padding: ${(props) => props.padding || '3rem'};
-  margin: ${(props) => props.margin || '1rem 1rem'};
-  border-radius: ${(props) => props.borderRadius || '0.5rem'};
-  font-size: ${(props) => props.fontSize || '1.1rem;'};
-  color: ${(props) => props.fontSize || 'white'};
-  background-color: ${(props) => props.backgroundColor || props.theme.color_background__secondary};
-`;
-*/
+
 const PlaceHolder = styled.div`
   text-align: center;
   padding: ${(props) => props.padding || '3rem'};

--- a/src/components/Shared/ValidationModal.js
+++ b/src/components/Shared/ValidationModal.js
@@ -27,19 +27,6 @@ const ModalContainer = styled(Box)`
   }
 `;
 
-/*
-const Text = styled.h1`
-  font-weight: 600;
-  font-size: 1.8rem;
-  color: ${(props) => props.theme.color_font__primary};
-`;
-
-const SubText = styled.h2`
-  font-size: 1.2rem;
-  color: ${(props) => props.theme.color_font__primary};
-`;
-*/
-
 const Text = styled.h1`
   font-weight: 600;
   font-size: 1.8rem;


### PR DESCRIPTION
## 작업 내용
- 마이페이지 히스토리
  - placeholder 배경색 제거
  - 거래횟수 숫자 문자 배열 조정

## 참고 자료
- <img width="614" alt="image" src="https://user-images.githubusercontent.com/102042966/185644201-8ae50a0d-8441-4d92-b410-0b127a36fe58.png">


## 기타 사항
- 

## 희망 완료일
- 
