### PR TITLE
feat: 경매 상세 페이지 itemName Tooltip 추가

### DIFF
--- a/src/components/Auction/AuctionDetail/AuctionItem.js
+++ b/src/components/Auction/AuctionDetail/AuctionItem.js
@@ -12,6 +12,8 @@ import { useState } from 'react';
 import AuctionDetailModal from './AuctionDetailModal';
 import { useParams } from 'react-router-dom';
 import isAuctionFinishedHandler from 'utils/isAuctionFinishedHandler';
+import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
+
 
 const Container = styled.div`
   position: relative;
@@ -145,6 +147,24 @@ const InterestedButton = styled.button`
   color: ${(props) => props.theme.color_white};
 `;
 
+const StyledTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))({
+  [`& .${tooltipClasses.tooltip}`]: {
+    maxWidth: 168,
+    cursor: 'pointer',
+    color: '#DFDCEF',
+    backgroundColor: '#000000',
+    fontSize: '1rem',
+    lineHeight: '1rem',
+    padding: '0.5rem'
+  },
+  [`& .${tooltipClasses.arrow}`]: {
+    color: '#000',
+  },
+});
+
+
 const AuctionItem = (props) => {
   const [isModalOpened, setIsModalOpened] = useState(false);
 
@@ -200,7 +220,12 @@ const AuctionItem = (props) => {
       </ItemImgContainer>
       <ItemContentContainer>
         <ItemNameContainer>
-          <ItemName>{props?.singleAuctionData?.title}</ItemName>
+          <StyledTooltip
+            title={props?.singleAuctionData?.title}
+            arrow
+          >
+            <ItemName>{props?.singleAuctionData?.title}</ItemName>
+          </StyledTooltip>
         </ItemNameContainer>
         <ItemDescriptionContainer>
           <ItemDescription>


### PR DESCRIPTION
## 작업 내용
- 경매 상세 페이지의 경매 제목 길어서 말줄임표 되는 경우, 경매 제목 전체 보기 위한 tooltip 추가

## 참고 자료
- <img width="207" alt="image" src="https://user-images.githubusercontent.com/102042966/185679041-95bd0d07-fc40-46a5-80ca-513e8243a54e.png">


## 기타 사항
-

## 희망 완료일
- 
